### PR TITLE
Fix image paths for per-day folders

### DIFF
--- a/templates/exercise.html
+++ b/templates/exercise.html
@@ -10,7 +10,7 @@
   <li>Target: {{ exercise['target'] }}</li>
 </ul>
 <p>
-  <img src="{{ url_for('static', filename='img/' + (exercise['EJERCICIO']|slugify) + '.png') }}" alt="Imagen del ejercicio" width="300">
+  <img src="{{ url_for('static', filename='img/' + day + '/' + (exercise['EJERCICIO']|slugify) + '.png') }}" alt="Imagen del ejercicio" width="300">
 </p>
 <h3>Ejecución</h3>
 <ul>


### PR DESCRIPTION
## Summary
- show exercise images from day-specific subfolders

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688908af21688329a8f0718fa397e331