### PR TITLE
Persist timers across pages

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1,9 +1,30 @@
 let totalStart = null;
 let totalTimer;
+let restStart = null;
+let restDuration = 0;
+
+function saveTotal() {
+  if (totalStart !== null) {
+    localStorage.setItem('totalStart', totalStart.toString());
+  } else {
+    localStorage.removeItem('totalStart');
+  }
+}
+
+function saveRest() {
+  if (restStart !== null && restDuration > 0) {
+    localStorage.setItem('restStart', restStart.toString());
+    localStorage.setItem('restDuration', restDuration.toString());
+  } else {
+    localStorage.removeItem('restStart');
+    localStorage.removeItem('restDuration');
+  }
+}
 
 function startTotal() {
   if (totalStart !== null) return;
   totalStart = Date.now();
+  saveTotal();
   updateTotal();
   totalTimer = setInterval(updateTotal, 1000);
   const btn = document.getElementById('start-btn');
@@ -21,19 +42,54 @@ function updateTotal() {
 
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('start-btn');
-  if (btn) btn.addEventListener('click', startTotal);
+  const savedTotal = localStorage.getItem('totalStart');
+  if (savedTotal) {
+    totalStart = parseInt(savedTotal, 10);
+    updateTotal();
+    totalTimer = setInterval(updateTotal, 1000);
+    if (btn) btn.style.display = 'none';
+  } else if (btn) {
+    btn.addEventListener('click', startTotal);
+  }
+
+  const rs = localStorage.getItem('restStart');
+  const rd = localStorage.getItem('restDuration');
+  if (rs && rd) {
+    restStart = parseInt(rs, 10);
+    restDuration = parseInt(rd, 10);
+    let remain = restDuration - Math.floor((Date.now() - restStart)/1000);
+    if (remain > 0) {
+      document.getElementById('rest').textContent = formatTime(remain);
+      restInterval = setInterval(updateRest, 1000);
+    } else {
+      restStart = null;
+      restDuration = 0;
+      saveRest();
+      document.getElementById('rest').textContent = '';
+    }
+  }
 });
 
 let restInterval;
 function startRest(seconds) {
   clearInterval(restInterval);
-  let remain = seconds;
-  document.getElementById('rest').textContent = formatTime(remain);
-  restInterval = setInterval(() => {
-    remain--;
-    document.getElementById('rest').textContent = formatTime(remain);
-    if (remain <= 0) clearInterval(restInterval);
-  }, 1000);
+  restStart = Date.now();
+  restDuration = seconds;
+  saveRest();
+  updateRest();
+  restInterval = setInterval(updateRest, 1000);
+}
+function updateRest() {
+  if (restStart === null) return;
+  const elapsed = Math.floor((Date.now() - restStart) / 1000);
+  const remain = restDuration - elapsed;
+  document.getElementById('rest').textContent = formatTime(Math.max(remain, 0));
+  if (remain <= 0) {
+    clearInterval(restInterval);
+    restStart = null;
+    restDuration = 0;
+    saveRest();
+  }
 }
 function formatTime(sec) {
   let m = Math.floor(sec/60);


### PR DESCRIPTION
## Summary
- keep track of total and rest timers in `localStorage`
- restore timers when any page loads
- clean stored values once the rest timer finishes

## Testing
- `python3 -m py_compile app.py`
- `node -c static/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68891df8321483298efae6fa92ecc1af