### PR TITLE
Add routine summary page with chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,10 @@ Luego abre `http://localhost:5000` en tu navegador. Podrás seleccionar un día 
 
 La página muestra un contador con el tiempo total transcurrido y botones para iniciar un cronómetro de descanso de 1 minuto o 1 minuto y 30 segundos.
 
-Al comenzar la rutina puedes pulsar **Finalizar Rutina** para detener el contador. Se mostrará el porcentaje de ejercicios completados y el tiempo total invertido y se reiniciará el estado del día.
+Al finalizar la rutina pulsa **Finalizar Rutina**. Ahora serás redirigido a una
+página de resumen que indica el tiempo invertido, el porcentaje completado y los
+grupos musculares trabajados. También se muestra un pequeño gráfico generado con
+Chart.js.
+
+No es necesario instalar nada adicional para el gráfico ya que Chart.js se
+carga desde una CDN.

--- a/app.py
+++ b/app.py
@@ -82,5 +82,38 @@ def exercise_view(day, idx):
     done = STATE.get(day, {}).get(str(idx), False)
     return render_template('exercise.html', day=day, idx=idx, exercise=exercise, done=done)
 
+@app.route('/summary/<day>', methods=['GET', 'POST'])
+def summary(day):
+    """Show summary of completed exercises for the given day."""
+    exercises = ROUTINES.get(day, [])
+    done_param = request.values.get('done', '')
+    time_param = request.values.get('time', '0')
+    try:
+        total_time = int(time_param)
+    except ValueError:
+        total_time = 0
+
+    done_idxs = []
+    for part in done_param.split(','):
+        if part.isdigit():
+            done_idxs.append(int(part))
+
+    percent = round(len(done_idxs) / len(exercises) * 100) if exercises else 0
+
+    muscles = []
+    counts = {}
+    for i in done_idxs:
+        if 0 <= i < len(exercises):
+            target = exercises[i].get('target', 'Desconocido')
+            muscles.append(target)
+            counts[target] = counts.get(target, 0) + 1
+
+    m = total_time // 60
+    s = total_time % 60
+    time_str = f"{m}:{s:02}"
+
+    return render_template('summary.html', day=day, time=time_str,
+                           percent=percent, muscles=muscles, counts=counts)
+
 if __name__ == '__main__':
     app.run(debug=True)

--- a/static/main.js
+++ b/static/main.js
@@ -44,24 +44,17 @@ function stopTotal() {
 function finishRoutine() {
   if (totalStart === null) return;
   const diff = Date.now() - totalStart;
-  const sec = Math.floor(diff / 1000);
-  const m = Math.floor(sec / 60);
-  const s = sec % 60;
-  const total = document.querySelectorAll('input[type="checkbox"]').length;
-  const done = document.querySelectorAll('input[type="checkbox"]:checked').length;
-  const percent = total ? Math.round(done / total * 100) : 0;
-  alert(`Completaste ${percent}% en ${m}:${s.toString().padStart(2,'0')}`);
+  const timeSec = Math.floor(diff / 1000);
+  const checked = Array.from(document.querySelectorAll('input[type="checkbox"]:checked'));
+  const indices = checked.map(cb => cb.dataset.idx);
   stopTotal();
-  const finish = document.getElementById('finish-btn');
-  if (finish) finish.style.display = 'none';
-  const startBtn = document.getElementById('start-btn');
-  if (startBtn) startBtn.style.display = '';
-  document.querySelectorAll('input[type="checkbox"]').forEach(cb => {
-    cb.disabled = true;
-    cb.checked = false;
-  });
   if (window.currentDay) {
-    fetch(`/reset/${window.currentDay}`, {method: 'POST'});
+    fetch(`/reset/${window.currentDay}`, {method: 'POST'}).finally(() => {
+      const params = new URLSearchParams();
+      params.set('time', timeSec.toString());
+      if (indices.length) params.set('done', indices.join(','));
+      window.location.href = `/summary/${window.currentDay}?` + params.toString();
+    });
   }
 }
 

--- a/templates/day.html
+++ b/templates/day.html
@@ -9,7 +9,7 @@
   <tbody>
   {% for e in exercises %}
   <tr>
-    <td><input type="checkbox" data-idx="{{ loop.index0 }}" {% if done.get(loop.index0|string) %}checked{% endif %}></td>
+    <td><input type="checkbox" data-idx="{{ loop.index0 }}" data-target="{{ e['target'] }}" {% if done.get(loop.index0|string) %}checked{% endif %}></td>
     <td><a href="{{ url_for('exercise_view', day=day, idx=loop.index0) }}">{{ e['EJERCICIO'] }}</a></td>
     <td>{{ e['REPETICIONES'] }}</td>
     <td>{{ e['SERIES'] }}</td>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>¡Felicidades!</h1>
+<p>Completaste {{ percent }}% de la rutina en {{ time }}.</p>
+{% if muscles %}
+<p>Trabajaste los siguientes grupos musculares:</p>
+<ul>
+  {% for m in muscles %}
+  <li>{{ m }}</li>
+  {% endfor %}
+</ul>
+<canvas id="muscleChart" width="300" height="300"></canvas>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const counts = {{ counts|tojson }};
+const ctx = document.getElementById('muscleChart').getContext('2d');
+new Chart(ctx, {
+  type: 'pie',
+  data: {
+    labels: Object.keys(counts),
+    datasets: [{ data: Object.values(counts) }]
+  }
+});
+</script>
+{% else %}
+<p>No marcaste ejercicios como realizados.</p>
+{% endif %}
+<p><a href="{{ url_for('index') }}">Volver al inicio</a></p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- capture muscle target in day view checkboxes
- add `/summary/<day>` route for results
- implement summary template with Chart.js pie chart
- redirect to summary screen when finishing routine
- mention summary screen in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68894521b52883298e5ec87cef419e1c