### PR TITLE
Add per-user sessions and chart-only summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Ejecuta la aplicación con:
 python app.py
 ```
 
-Luego abre `http://localhost:5000` en tu navegador. Podrás seleccionar un día y ver los ejercicios con casillas para marcar cada uno como realizado. El estado se guarda en `state.txt`.
+Luego abre `http://localhost:5000` en tu navegador. Al ingresar se te pedirá un nombre de usuario. Cada nombre mantiene su propio progreso en `state.txt` y no afecta al de otros usuarios. Después de identificarte podrás seleccionar un día y ver los ejercicios con casillas para marcar cada uno como realizado.
 
 La página muestra un contador con el tiempo total transcurrido y botones para iniciar un cronómetro de descanso de 1 minuto o 1 minuto y 30 segundos.
 
-Al finalizar la rutina pulsa **Finalizar Rutina**. Ahora serás redirigido a una
-página de resumen que indica el tiempo invertido, el porcentaje completado y los
-grupos musculares trabajados. También se muestra un pequeño gráfico generado con
-Chart.js.
+Al finalizar la rutina pulsa **Finalizar Rutina**. Se mostrará una pantalla de
+resumen con tu nombre, el tiempo invertido y el porcentaje completado junto a
+un gráfico de los grupos musculares trabajados. El gráfico incluye su leyenda
+para una lectura clara y está generado con Chart.js.
 
 No es necesario instalar nada adicional para el gráfico ya que Chart.js se
 carga desde una CDN.

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Selecciona un día</h1>
+<h1>Bienvenido, {{ username }}</h1>
+<p>Selecciona un día</p>
 <ul>
   {% for d in days %}
     <li><a href="{{ url_for('day_view', day=d) }}">Día {{ d }}</a></li>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Ingresa tu nombre</h1>
+<form method="post" action="{{ url_for('index') }}">
+  <input type="text" name="username" required>
+  <button type="submit">Entrar</button>
+</form>
+{% endblock %}

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -1,14 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>¡Felicidades!</h1>
+<h1>¡Felicidades, {{ username }}!</h1>
 <p>Completaste {{ percent }}% de la rutina en {{ time }}.</p>
 {% if muscles %}
-<p>Trabajaste los siguientes grupos musculares:</p>
-<ul>
-  {% for m in muscles %}
-  <li>{{ m }}</li>
-  {% endfor %}
-</ul>
 <canvas id="muscleChart" width="300" height="300"></canvas>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
@@ -19,6 +13,9 @@ new Chart(ctx, {
   data: {
     labels: Object.keys(counts),
     datasets: [{ data: Object.values(counts) }]
+  },
+  options: {
+    plugins: { legend: { display: true } }
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- manage state per username using Flask sessions and nested state file
- ask for username on first visit and greet on index
- show username on final summary with only pie chart and legend
- document the new flow

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688942874cb4832983481635d51950d6