### PR TITLE
Add alert to start routine before marking done

### DIFF
--- a/templates/day.html
+++ b/templates/day.html
@@ -29,6 +29,11 @@
   window.totalExercises = {{ exercises|length }};
   document.querySelectorAll('input[type="checkbox"]').forEach(cb => {
     cb.addEventListener('change', () => {
+      if (cb.checked && window.totalStart === null) {
+        alert('Por favor inicia la rutina antes de marcar ejercicios como realizados.');
+        cb.checked = false;
+        return;
+      }
       fetch(`/toggle/${dayId}/${cb.dataset.idx}`, {method: 'POST'});
     });
   });


### PR DESCRIPTION
## Summary
- prevent checking an exercise before starting the routine

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889511c404483298712243c06f64cc9