### PR TITLE
Scope timer state by user

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,11 @@ from flask import Flask, render_template, request, redirect, url_for, session
 app = Flask(__name__)
 app.secret_key = 'change-me'
 
+# Make the current username available in every template
+@app.context_processor
+def inject_username():
+    return {'username': session.get('username')}
+
 def slugify(value: str) -> str:
     value = value.lower()
     value = unicodedata.normalize('NFKD', value)

--- a/static/main.js
+++ b/static/main.js
@@ -4,21 +4,25 @@ let totalTimer;
 window.restStart = null;
 let restDuration = 0;
 
+function key(name) {
+  return window.username ? `${name}_${window.username}` : name;
+}
+
 function saveTotal() {
   if (window.totalStart !== null) {
-    localStorage.setItem('totalStart', window.totalStart.toString());
+    localStorage.setItem(key('totalStart'), window.totalStart.toString());
   } else {
-    localStorage.removeItem('totalStart');
+    localStorage.removeItem(key('totalStart'));
   }
 }
 
 function saveRest() {
   if (window.restStart !== null && restDuration > 0) {
-    localStorage.setItem('restStart', window.restStart.toString());
-    localStorage.setItem('restDuration', restDuration.toString());
+    localStorage.setItem(key('restStart'), window.restStart.toString());
+    localStorage.setItem(key('restDuration'), restDuration.toString());
   } else {
-    localStorage.removeItem('restStart');
-    localStorage.removeItem('restDuration');
+    localStorage.removeItem(key('restStart'));
+    localStorage.removeItem(key('restDuration'));
   }
 }
 
@@ -71,7 +75,7 @@ function updateTotal() {
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('start-btn');
   const finishBtn = document.getElementById('finish-btn');
-  const savedTotal = localStorage.getItem('totalStart');
+  const savedTotal = localStorage.getItem(key('totalStart'));
   if (savedTotal) {
     window.totalStart = parseInt(savedTotal, 10);
     updateTotal();
@@ -83,8 +87,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   if (finishBtn) finishBtn.addEventListener('click', finishRoutine);
 
-  const rs = localStorage.getItem('restStart');
-  const rd = localStorage.getItem('restDuration');
+  const rs = localStorage.getItem(key('restStart'));
+  const rd = localStorage.getItem(key('restDuration'));
   if (rs && rd) {
     window.restStart = parseInt(rs, 10);
     restDuration = parseInt(rd, 10);

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,6 +38,10 @@
   </div>
 </div>
 {% block content %}{% endblock %}
+<script>
+  // Expose the current username to client-side scripts
+  window.username = {{ (username or '')|tojson }};
+</script>
 <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- inject username into all templates via a context processor
- expose that username to the client in `base.html`
- prefix localStorage keys with the username so timers persist per-user

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68895718168c8329908dbe5606527a7d