### PR TITLE
Toggle endpoint accepts explicit state

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 import unicodedata
-from flask import Flask, render_template, request, redirect, url_for, session
+from flask import Flask, render_template, request, redirect, url_for, session, jsonify
 
 app = Flask(__name__)
 app.secret_key = 'change-me'
@@ -95,9 +95,16 @@ def toggle(day, idx):
         return ('', 400)
     user_state = get_user_state(username)
     state_day = user_state.setdefault(day, {})
-    state_day[str(idx)] = not state_day.get(str(idx), False)
+    data = request.get_json(silent=True) or {}
+    value = data.get('state')
+    checked = False
+    if isinstance(value, str):
+        checked = value == 'checked'
+    elif isinstance(value, bool):
+        checked = value
+    state_day[str(idx)] = checked
     save_state()
-    return ('', 204)
+    return jsonify({str(idx): checked})
 
 # New endpoint to reset all checkboxes for a day
 @app.route('/reset/<day>', methods=['POST'])

--- a/templates/day.html
+++ b/templates/day.html
@@ -34,7 +34,12 @@
         cb.checked = false;
         return;
       }
-      fetch(`/toggle/${dayId}/${cb.dataset.idx}`, {method: 'POST'});
+      const value = cb.checked ? 'checked' : 'unchecked';
+      fetch(`/toggle/${dayId}/${cb.dataset.idx}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ state: value })
+      }).then(r => r.json()).then(console.log);
     });
   });
 </script>


### PR DESCRIPTION
## Summary
- send the checkbox state in `/toggle` request
- store given value on the server instead of flipping
- return JSON with the updated state

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688957ec9a48832986ad03f10df1891d