### PR TITLE
Limit timer to workout pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,7 +84,8 @@ def day_view(day):
     user_state = get_user_state(username)
     exercises = ROUTINES.get(day, [])
     done = user_state.get(day, {})
-    return render_template('day.html', day=day, exercises=exercises, done=done)
+    return render_template('day.html', day=day, exercises=exercises, done=done,
+                           show_timer=True)
 
 @app.route('/logout')
 def logout():
@@ -138,7 +139,8 @@ def exercise_view(day, idx):
         save_state()
         return redirect(url_for('day_view', day=day))
     done = user_state.get(day, {}).get(str(idx), False)
-    return render_template('exercise.html', day=day, idx=idx, exercise=exercise, done=done)
+    return render_template('exercise.html', day=day, idx=idx, exercise=exercise,
+                           done=done, show_timer=True)
 
 @app.route('/summary/<day>', methods=['GET', 'POST'])
 def summary(day):

--- a/static/main.js
+++ b/static/main.js
@@ -36,6 +36,7 @@ function startTotal() {
   if (btn) btn.style.display = 'none';
   const finish = document.getElementById('finish-btn');
   if (finish) finish.style.display = '';
+  document.querySelectorAll('.back-btn').forEach(b => b.style.display = 'none');
 }
 
 function stopTotal() {
@@ -44,6 +45,7 @@ function stopTotal() {
   window.totalStart = null;
   saveTotal();
   document.getElementById('total').textContent = '0:00';
+  document.querySelectorAll('.back-btn').forEach(b => b.style.display = '');
 }
 
 function finishRoutine() {
@@ -82,6 +84,7 @@ document.addEventListener('DOMContentLoaded', () => {
     totalTimer = setInterval(updateTotal, 1000);
     if (btn) btn.style.display = 'none';
     if (finishBtn) finishBtn.style.display = '';
+    document.querySelectorAll('.back-btn').forEach(b => b.style.display = 'none');
   } else if (btn) {
     btn.addEventListener('click', startTotal);
   }

--- a/templates/base.html
+++ b/templates/base.html
@@ -27,6 +27,7 @@
   </style>
 </head>
 <body>
+{% if show_timer %}
 <div class="timer">
   <button id="start-btn">Iniciar Rutina</button>
   <button id="finish-btn" style="display:none;">Finalizar Rutina</button>
@@ -37,6 +38,7 @@
     <div>Restante: <span id="rest"></span></div>
   </div>
 </div>
+{% endif %}
 {% block content %}{% endblock %}
 <script>
   // Expose the current username to client-side scripts

--- a/templates/day.html
+++ b/templates/day.html
@@ -18,7 +18,7 @@
   </tbody>
 </table>
 <p>
-  <button onclick="window.location.href='{{ url_for('index') }}'">Regresar</button>
+  <button class="back-btn" onclick="window.location.href='{{ url_for('index') }}'">Regresar</button>
 </p>
 {% else %}
 <p>No hay datos para este día.</p>

--- a/templates/exercise.html
+++ b/templates/exercise.html
@@ -26,6 +26,6 @@
 </ul>
 <form method="post">
   <button type="submit">Realizado</button>
-  <button type="button" onclick="window.location.href='{{ url_for('day_view', day=day) }}'">Regresar</button>
+  <button type="button" class="back-btn" onclick="window.location.href='{{ url_for('day_view', day=day) }}'">Regresar</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- timer shows only on day/exercise pages
- hide back button once the routine starts
- allow exercise and day pages to enable the timer display

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68895b8652e88329afaaf3bc1b35a800