### PR TITLE
Hide back button only on day page during routine

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -36,7 +36,7 @@ function startTotal() {
   if (btn) btn.style.display = 'none';
   const finish = document.getElementById('finish-btn');
   if (finish) finish.style.display = '';
-  document.querySelectorAll('.back-btn').forEach(b => b.style.display = 'none');
+  document.querySelectorAll('.day-back-btn').forEach(b => b.style.display = 'none');
 }
 
 function stopTotal() {
@@ -45,7 +45,7 @@ function stopTotal() {
   window.totalStart = null;
   saveTotal();
   document.getElementById('total').textContent = '0:00';
-  document.querySelectorAll('.back-btn').forEach(b => b.style.display = '');
+  document.querySelectorAll('.day-back-btn').forEach(b => b.style.display = '');
 }
 
 function finishRoutine() {
@@ -84,7 +84,7 @@ document.addEventListener('DOMContentLoaded', () => {
     totalTimer = setInterval(updateTotal, 1000);
     if (btn) btn.style.display = 'none';
     if (finishBtn) finishBtn.style.display = '';
-    document.querySelectorAll('.back-btn').forEach(b => b.style.display = 'none');
+    document.querySelectorAll('.day-back-btn').forEach(b => b.style.display = 'none');
   } else if (btn) {
     btn.addEventListener('click', startTotal);
   }

--- a/templates/day.html
+++ b/templates/day.html
@@ -18,7 +18,7 @@
   </tbody>
 </table>
 <p>
-  <button class="btn back-btn" onclick="window.location.href='{{ url_for('index') }}'">Regresar</button>
+  <button class="btn back-btn day-back-btn" onclick="window.location.href='{{ url_for('index') }}'">Regresar</button>
 </p>
 {% else %}
 <p>No hay datos para este día.</p>


### PR DESCRIPTION
## Summary
- hide only the day page's back button when the routine starts
- keep exercise page navigation visible

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6889608149e083299665196b3b957021