### PR TITLE
Improve summary tooltips

### DIFF
--- a/app.py
+++ b/app.py
@@ -187,6 +187,7 @@ def summary(day):
 
     muscles = []
     counts = {}
+    muscles_by_group = {}
     for i in done_idxs:
         if 0 <= i < len(exercises):
             ids = exercises[i].get('muscles', [])
@@ -197,13 +198,17 @@ def summary(day):
                 muscles.append(m['name'])
                 g_name = MUSCLE_GROUPS.get(m.get('group'), m.get('group'))
                 counts[g_name] = counts.get(g_name, 0) + 1
+                muscles_by_group.setdefault(g_name, set()).add(m['name'])
 
     m = total_time // 60
     s = total_time % 60
     time_str = f"{m}:{s:02}"
 
+    muscles_by_group = {g: sorted(list(ms)) for g, ms in muscles_by_group.items()}
+
     return render_template('summary.html', day=day, time=time_str,
                            percent=percent, muscles=muscles, counts=counts,
+                           muscles_by_group=muscles_by_group,
                            username=username)
 
 if __name__ == '__main__':

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -8,6 +8,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
 const counts = {{ counts|tojson }};
+const musclesByGroup = {{ muscles_by_group|tojson }};
 const ctx = document.getElementById('muscleChart').getContext('2d');
 new Chart(ctx, {
   type: 'pie',
@@ -16,7 +17,18 @@ new Chart(ctx, {
     datasets: [{ data: Object.values(counts) }]
   },
   options: {
-    plugins: { legend: { display: true } }
+    plugins: {
+      legend: { display: true },
+      tooltip: {
+        callbacks: {
+          label: function(ctx) {
+            const group = ctx.label || '';
+            const muscles = musclesByGroup[group] || [];
+            return group + ': ' + muscles.join(', ');
+          }
+        }
+      }
+    }
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- collect list of muscles per group in the summary view
- show those muscle names in the Chart.js tooltip

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a289c1f888329bce0a5737a334d88