### PR TITLE
Friendly welcome, name preservation and draggable timer

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -106,7 +106,43 @@ document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('rest').textContent = '';
     }
   }
+
+  const timer = document.querySelector('.timer');
+  if (timer) {
+    const saved = localStorage.getItem('timerPos');
+    if (saved) {
+      try {
+        const pos = JSON.parse(saved);
+        timer.style.left = pos.x + 'px';
+        timer.style.top = pos.y + 'px';
+        timer.style.right = 'auto';
+      } catch (e) {}
+    }
+    makeDraggable(timer);
+  }
 });
+
+function makeDraggable(el) {
+  let dragging = false;
+  let offsetX = 0;
+  let offsetY = 0;
+  el.addEventListener('mousedown', e => {
+    dragging = true;
+    offsetX = e.clientX - el.offsetLeft;
+    offsetY = e.clientY - el.offsetTop;
+    el.style.right = 'auto';
+  });
+  document.addEventListener('mousemove', e => {
+    if (!dragging) return;
+    el.style.left = (e.clientX - offsetX) + 'px';
+    el.style.top = (e.clientY - offsetY) + 'px';
+  });
+  document.addEventListener('mouseup', () => {
+    if (!dragging) return;
+    dragging = false;
+    localStorage.setItem('timerPos', JSON.stringify({x: el.offsetLeft, y: el.offsetTop}));
+  });
+}
 
 let restInterval;
 function startRest(seconds) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,6 +19,7 @@
       background: #eee;
       padding: 10px;
       border-radius: 5px;
+      cursor: move;
     }
     .rest { margin-top: 10px; }
     .day-table { width: 100%; border-collapse: collapse; margin-top: 1em; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Bienvenido, {{ username }}</h1>
-<p>Selecciona un día</p>
+<h1>¡Hola {{ username }}!</h1>
+<p>Elige un día para comenzar tu rutina:</p>
 <ul>
   {% for d in days %}
     <li><button class="btn" onclick="window.location.href='{{ url_for('day_view', day=d) }}'">Día {{ d }}</button></li>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,8 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Ingresa tu nombre</h1>
+<h1>¡Bienvenido!</h1>
+<p>Para empezar, por favor escribe tu nombre:</p>
 <form method="post" action="{{ url_for('index') }}">
   <input type="text" name="username" required>
-  <button class="btn" type="submit">Entrar</button>
+  <button class="btn" type="submit">Comenzar</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- keep raw username for display while using a slugged id internally
- improve login greeting and index welcome messages
- add drag capability to timer widget

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688a2a79f47083299801c14894dd7191